### PR TITLE
Remove application configurations from manifest

### DIFF
--- a/prem/src/main/AndroidManifest.xml
+++ b/prem/src/main/AndroidManifest.xml
@@ -3,9 +3,7 @@
     package="io.github.tslamic.prem">
 
     <uses-permission android:name="com.android.vending.BILLING" />
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name" />
+    
+    <application/>
 
 </manifest>


### PR DESCRIPTION
Since this is a manifest from a library, that configurations should not be included.
